### PR TITLE
fix: dynamically set headers for Anthropic API

### DIFF
--- a/src/components/AISettings.vue
+++ b/src/components/AISettings.vue
@@ -437,12 +437,20 @@ export default {
       try {
         // Use normalized URL for models endpoint
         const modelsEndpoint = `${this.aiSettings.apiUrl}/models`;
+        
+        // Set up headers based on the API endpoint
+        const headers = {};
+        
+        // Add authentication header based on the API endpoint
+        if (this.aiSettings.apiUrl === 'https://api.anthropic.com/v1') {
+          headers['x-api-key'] = this.aiSettings.apiKey;
+          headers['anthropic-dangerous-direct-browser-access'] = 'true';
+          headers['anthropic-version'] = '2023-06-01';
+        } else {
+          headers['Authorization'] = `Bearer ${this.aiSettings.apiKey}`;
+        }
           
-        const response = await axios.get(modelsEndpoint, {
-          headers: {
-            'Authorization': `Bearer ${this.aiSettings.apiKey}`
-          }
-        });
+        const response = await axios.get(modelsEndpoint, { headers });
         
         if (response.data && response.data.data) {
           // Minimal filtering to include more models

--- a/src/services/OpenAIService.js
+++ b/src/services/OpenAIService.js
@@ -198,6 +198,20 @@ My current movies: ${movieTitles}`;
    */
   async getFormattedRecommendations(messages) {
     try {
+      // Define headers based on the API endpoint
+      const headers = {};
+      
+      // Add authentication header based on the API endpoint
+      if (this.baseUrl === 'https://api.anthropic.com/v1') {
+        headers['x-api-key'] = this.apiKey;
+        headers['anthropic-dangerous-direct-browser-access'] = 'true';
+        headers['anthropic-version'] = '2023-06-01';
+      } else {
+        headers['Authorization'] = `Bearer ${this.apiKey}`;
+      }
+      
+      headers['Content-Type'] = 'application/json';
+
       const response = await axios.post(
         this.apiUrl,
         {
@@ -208,12 +222,7 @@ My current movies: ${movieTitles}`;
           presence_penalty: 0.1,  // Slightly discourage repetition
           frequency_penalty: 0.1  // Slightly encourage diversity
         },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${this.apiKey}`
-          }
-        }
+        { headers }
       );
 
       // Parse the recommendations from the response


### PR DESCRIPTION
Anthropic's API requires some additional and different headers, this PR allows you to use the `https://api.anthropic.com/v1` endpoint. I wanted to add support for Anthropic as their `claude-3-7-sonnet-20250219` has a knowledge cut-off date of November 2024 so I figured it should give better recommendations vs OpenAI's October 2023 cut-off

`x-api-key` instead of `Bearer`
`anthropic-version` this is required
`anthropic-dangerous-direct-browser-access` this should be set to `true` to avoid issues with CORS.

references:
https://simonwillison.net/2024/Aug/23/anthropic-dangerous-direct-browser-access/
https://docs.anthropic.com/en/api/complete