### PR TITLE
Dev/plex integration

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -238,6 +238,11 @@ export default {
         
         this.recentlyWatchedMovies = moviesResponse;
         this.recentlyWatchedShows = showsResponse;
+        
+        console.log('Fetched Plex watch history:', {
+          movies: this.recentlyWatchedMovies,
+          shows: this.recentlyWatchedShows
+        });
       } catch (error) {
         console.error('Failed to fetch Plex watch history:', error);
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@
     </header>
     
     <main>
-      <div v-if="!sonarrConnected && !radarrConnected">
+      <div v-if="!sonarrConnected && !radarrConnected && !plexConnected">
         <p class="choose-service">Choose a service to connect to:</p>
         <div class="service-buttons">
           <button class="service-button" @click="showSonarrConnect = true">
@@ -17,13 +17,18 @@
             Connect to Radarr
             <small>For movie recommendations</small>
           </button>
+          <button class="service-button plex-button" @click="showPlexConnect = true">
+            Connect to Plex
+            <small>For watch history integration</small>
+          </button>
         </div>
       </div>
       
       <SonarrConnection v-if="showSonarrConnect && !sonarrConnected" @connected="handleSonarrConnected" />
       <RadarrConnection v-if="showRadarrConnect && !radarrConnected" @connected="handleRadarrConnected" />
+      <PlexConnection v-if="showPlexConnect && !plexConnected" @connected="handlePlexConnected" @limitChanged="handlePlexLimitChanged" />
       
-      <div v-if="sonarrConnected || radarrConnected">
+      <div v-if="sonarrConnected || radarrConnected || plexConnected">
         <AppNavigation 
           :activeTab="activeTab" 
           @navigate="handleNavigate"
@@ -35,6 +40,8 @@
             v-if="activeTab === 'tv-recommendations'" 
             :series="series"
             :sonarrConfigured="sonarrConnected"
+            :recentlyWatchedShows="recentlyWatchedShows"
+            :plexConfigured="plexConnected"
             @navigate="handleNavigate" 
           />
           
@@ -42,6 +49,8 @@
             v-if="activeTab === 'movie-recommendations'" 
             :movies="movies"
             :radarrConfigured="radarrConnected"
+            :recentlyWatchedMovies="recentlyWatchedMovies"
+            :plexConfigured="plexConnected"
             @navigate="handleNavigate" 
           />
           
@@ -50,6 +59,7 @@
             @settings-updated="handleSettingsUpdated"
             @sonarr-settings-updated="handleSonarrSettingsUpdated"
             @radarr-settings-updated="handleRadarrSettingsUpdated"
+            @plex-settings-updated="handlePlexSettingsUpdated"
           />
         </div>
       </div>
@@ -60,18 +70,21 @@
 <script>
 import SonarrConnection from './components/SonarrConnection.vue'
 import RadarrConnection from './components/RadarrConnection.vue'
+import PlexConnection from './components/PlexConnection.vue'
 import AppNavigation from './components/Navigation.vue'
 import TVRecommendations from './components/TVRecommendations.vue'
 import MovieRecommendations from './components/MovieRecommendations.vue'
 import AISettings from './components/AISettings.vue'
 import sonarrService from './services/SonarrService'
 import radarrService from './services/RadarrService'
+import plexService from './services/PlexService'
 
 export default {
   name: 'App',
   components: {
     SonarrConnection,
     RadarrConnection,
+    PlexConnection,
     AppNavigation,
     TVRecommendations,
     MovieRecommendations,
@@ -81,11 +94,16 @@ export default {
     return {
       sonarrConnected: false,
       radarrConnected: false,
+      plexConnected: false,
       showSonarrConnect: false,
       showRadarrConnect: false,
+      showPlexConnect: false,
       activeTab: 'tv-recommendations',
       series: [],
-      movies: []
+      movies: [],
+      recentlyWatchedMovies: [],
+      recentlyWatchedShows: [],
+      plexRecentLimit: 10
     }
   },
   created() {
@@ -97,6 +115,17 @@ export default {
     // Check if Radarr is already configured on startup
     if (radarrService.isConfigured()) {
       this.checkRadarrConnection();
+    }
+    
+    // Check if Plex is already configured on startup
+    if (plexService.isConfigured()) {
+      this.checkPlexConnection();
+    }
+    
+    // Load Plex recent limit from localStorage if available
+    const savedPlexLimit = localStorage.getItem('plexRecentLimit');
+    if (savedPlexLimit) {
+      this.plexRecentLimit = parseInt(savedPlexLimit, 10);
     }
   },
   methods: {
@@ -129,6 +158,19 @@ export default {
         console.error('Failed to connect with stored Radarr credentials:', error);
       }
     },
+    
+    async checkPlexConnection() {
+      try {
+        const success = await plexService.testConnection();
+        if (success) {
+          this.plexConnected = true;
+          this.fetchPlexData();
+        }
+      } catch (error) {
+        console.error('Failed to connect with stored Plex credentials:', error);
+      }
+    },
+    
     handleSonarrConnected() {
       this.sonarrConnected = true;
       this.showSonarrConnect = false;
@@ -141,6 +183,17 @@ export default {
       this.showRadarrConnect = false;
       this.fetchMoviesData();
       this.activeTab = 'movie-recommendations';
+    },
+    
+    handlePlexConnected() {
+      this.plexConnected = true;
+      this.showPlexConnect = false;
+      this.fetchPlexData();
+    },
+    
+    handlePlexLimitChanged(limit) {
+      this.plexRecentLimit = limit;
+      this.fetchPlexData();
     },
     handleNavigate(tab) {
       this.activeTab = tab;
@@ -170,6 +223,25 @@ export default {
         console.error('Failed to fetch movies data for recommendations:', error);
       }
     },
+    
+    async fetchPlexData() {
+      if (!plexService.isConfigured()) {
+        return;
+      }
+      
+      try {
+        // Fetch both shows and movies in parallel for efficiency
+        const [moviesResponse, showsResponse] = await Promise.all([
+          plexService.getRecentlyWatchedMovies(this.plexRecentLimit),
+          plexService.getRecentlyWatchedShows(this.plexRecentLimit)
+        ]);
+        
+        this.recentlyWatchedMovies = moviesResponse;
+        this.recentlyWatchedShows = showsResponse;
+      } catch (error) {
+        console.error('Failed to fetch Plex watch history:', error);
+      }
+    },
     handleSettingsUpdated() {
       // When AI settings are updated, show a brief notification or just stay on the settings page
       console.log('AI settings updated successfully');
@@ -186,26 +258,39 @@ export default {
       this.checkRadarrConnection();
       console.log('Radarr settings updated, testing connection');
     },
+    
+    handlePlexSettingsUpdated() {
+      // Check the Plex connection with the new settings
+      this.checkPlexConnection();
+      console.log('Plex settings updated, testing connection');
+    },
     handleLogout() {
       // Clear all stored credentials
       localStorage.removeItem('sonarrBaseUrl');
       localStorage.removeItem('sonarrApiKey');
       localStorage.removeItem('radarrBaseUrl');
       localStorage.removeItem('radarrApiKey');
+      localStorage.removeItem('plexBaseUrl');
+      localStorage.removeItem('plexToken');
       localStorage.removeItem('openaiApiKey');
       localStorage.removeItem('openaiModel');
       
       // Reset service configurations
       sonarrService.configure('', '');
       radarrService.configure('', '');
+      plexService.configure('', '');
       
       // Reset UI state
       this.sonarrConnected = false;
       this.radarrConnected = false;
+      this.plexConnected = false;
       this.series = [];
       this.movies = [];
+      this.recentlyWatchedMovies = [];
+      this.recentlyWatchedShows = [];
       this.showSonarrConnect = false;
       this.showRadarrConnect = false;
+      this.showPlexConnect = false;
       this.activeTab = 'tv-recommendations';
     }
   }
@@ -393,6 +478,14 @@ main {
   color: var(--button-primary-text);
   transform: translateY(-3px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.service-button.plex-button {
+  border-color: #CC7B19; /* Plex orange color */
+}
+
+.service-button.plex-button:hover {
+  background-color: #CC7B19;
 }
 
 .service-button small {

--- a/src/components/MovieRecommendations.vue
+++ b/src/components/MovieRecommendations.vue
@@ -152,6 +152,41 @@
                       </div>
                     </div>
                   </div>
+                  
+                  <div v-if="plexConfigured" class="plex-options">
+                    <label>Plex Watch History:</label>
+                    <div class="plex-history-toggle">
+                      <label class="toggle-option">
+                        <input 
+                          type="radio" 
+                          v-model="plexHistoryMode" 
+                          value="all"
+                          @change="savePlexHistoryMode"
+                        >
+                        All watch history
+                      </label>
+                      <label class="toggle-option">
+                        <input 
+                          type="radio" 
+                          v-model="plexHistoryMode" 
+                          value="recent"
+                          @change="savePlexHistoryMode"
+                        >
+                        Recent (30 days)
+                      </label>
+                    </div>
+                    
+                    <div class="plex-only-toggle">
+                      <label class="checkbox-label">
+                        <input 
+                          type="checkbox" 
+                          v-model="plexOnlyMode" 
+                          @change="savePlexOnlyMode"
+                        >
+                        Use only Plex history for recommendations (ignore library)
+                      </label>
+                    </div>
+                  </div>
                 </div>
               </div>
               
@@ -350,6 +385,8 @@ export default {
       numRecommendations: 5, // Default number of recommendations to request
       columnsCount: 2, // Default number of posters per row
       selectedGenres: [], // Multiple genre selections
+      plexHistoryMode: 'all', // 'all' or 'recent'
+      plexOnlyMode: false, // Whether to use only Plex history for recommendations
       availableGenres: [
         { value: 'action', label: 'Action' },
         { value: 'adventure', label: 'Adventure' },
@@ -551,6 +588,18 @@ export default {
     clearGenres() {
       this.selectedGenres = [];
       this.saveGenrePreference();
+    },
+    
+    // Save Plex history mode preference
+    savePlexHistoryMode() {
+      localStorage.setItem('plexHistoryMode', this.plexHistoryMode);
+      this.$emit('plexHistoryModeChanged', this.plexHistoryMode);
+    },
+    
+    // Save Plex only mode preference
+    savePlexOnlyMode() {
+      localStorage.setItem('plexOnlyMode', this.plexOnlyMode.toString());
+      this.$emit('plexOnlyModeChanged', this.plexOnlyMode);
     },
     
     // Save previous recommendations to localStorage
@@ -807,7 +856,8 @@ export default {
           this.previousRecommendations,
           this.likedRecommendations,
           this.dislikedRecommendations,
-          this.recentlyWatchedMovies
+          this.recentlyWatchedMovies,
+          this.plexOnlyMode
         );
         
         // Update loading message to include genres if selected
@@ -1014,6 +1064,18 @@ export default {
         console.error('Error parsing saved genres:', error);
         this.selectedGenres = [];
       }
+    }
+    
+    // Restore saved Plex history mode if it exists
+    const savedPlexHistoryMode = localStorage.getItem('plexHistoryMode');
+    if (savedPlexHistoryMode) {
+      this.plexHistoryMode = savedPlexHistoryMode;
+    }
+    
+    // Restore saved Plex only mode if it exists
+    const savedPlexOnlyMode = localStorage.getItem('plexOnlyMode');
+    if (savedPlexOnlyMode) {
+      this.plexOnlyMode = savedPlexOnlyMode === 'true';
     }
     
     // Load previous movie recommendations from localStorage
@@ -2098,6 +2160,39 @@ h2 {
   color: var(--text-color);
   opacity: 0.7;
   transition: color var(--transition-speed);
+}
+
+.plex-options {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: rgba(0, 0, 0, 0.02);
+  border-radius: 8px;
+}
+
+.plex-history-toggle {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.toggle-option {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  margin: 0;
+  font-size: 14px;
+}
+
+.toggle-option input[type="radio"] {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.plex-only-toggle {
+  margin-top: 15px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 .request-button {

--- a/src/components/MovieRecommendations.vue
+++ b/src/components/MovieRecommendations.vue
@@ -171,7 +171,7 @@
       
       <div v-if="loading" class="loading">
         <div class="spinner"></div>
-        <p>Analyzing your movie library and generating recommendations...</p>
+        <p>{{ plexConfigured ? 'Analyzing your movie library and Plex watch history...' : 'Analyzing your movie library and generating recommendations...' }}</p>
       </div>
       
       <div v-else-if="error" class="error">
@@ -317,6 +317,14 @@ export default {
     radarrConfigured: {
       type: Boolean,
       required: true
+    },
+    recentlyWatchedMovies: {
+      type: Array,
+      default: () => []
+    },
+    plexConfigured: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
@@ -789,13 +797,15 @@ export default {
           : '';
           
         // Pass the previous recommendations to be excluded and liked/disliked lists
+        // Include recently watched movies from Plex if available
         this.recommendations = await openAIService.getMovieRecommendations(
           this.movies, 
           this.numRecommendations,
           genreString,
           this.previousRecommendations,
           this.likedRecommendations,
-          this.dislikedRecommendations
+          this.dislikedRecommendations,
+          this.recentlyWatchedMovies
         );
         
         // Update loading message to include genres if selected

--- a/src/components/MovieRecommendations.vue
+++ b/src/components/MovieRecommendations.vue
@@ -206,7 +206,7 @@
       
       <div v-if="loading" class="loading">
         <div class="spinner"></div>
-        <p>{{ plexConfigured ? 'Analyzing your movie library and Plex watch history...' : 'Analyzing your movie library and generating recommendations...' }}</p>
+        <p>{{ plexOnlyMode ? 'Analyzing your Plex watch history...' : (plexConfigured ? 'Analyzing your movie library and Plex watch history...' : 'Analyzing your movie library and generating recommendations...') }}</p>
       </div>
       
       <div v-else-if="error" class="error">
@@ -863,7 +863,8 @@ export default {
         // Update loading message to include genres if selected
         const loadingMessage = document.querySelector('.loading p');
         if (loadingMessage && this.selectedGenres.length > 0) {
-          loadingMessage.textContent = `Analyzing your movie library and generating ${genreString} recommendations...`;
+          const source = this.plexOnlyMode ? 'Plex watch history' : 'movie library';
+          loadingMessage.textContent = `Analyzing your ${source} and generating ${genreString} recommendations...`;
         }
         
         // Add new recommendations to history

--- a/src/components/MovieRecommendations.vue
+++ b/src/components/MovieRecommendations.vue
@@ -798,6 +798,8 @@ export default {
           
         // Pass the previous recommendations to be excluded and liked/disliked lists
         // Include recently watched movies from Plex if available
+        console.log('Using Plex history for recommendations:', this.plexConfigured ? this.recentlyWatchedMovies : 'Not configured');
+        
         this.recommendations = await openAIService.getMovieRecommendations(
           this.movies, 
           this.numRecommendations,

--- a/src/components/PlexConnection.vue
+++ b/src/components/PlexConnection.vue
@@ -52,7 +52,7 @@
             v-model.number="recentLimit" 
             type="number" 
             min="1" 
-            max="50" 
+            max="100" 
             @change="saveRecentLimit"
           />
           <div class="limit-buttons">
@@ -76,7 +76,7 @@ export default {
       token: '',
       connectionStatus: null,
       connecting: false,
-      recentLimit: 10 // Default limit for recently watched items
+      recentLimit: 50 // Default limit for recently watched items
     };
   },
   created() {
@@ -204,7 +204,7 @@ export default {
       localStorage.removeItem('plexToken');
     },
     increaseLimit() {
-      if (this.recentLimit < 50) {
+      if (this.recentLimit < 100) {
         this.recentLimit++;
         this.saveRecentLimit();
       }
@@ -218,7 +218,7 @@ export default {
     saveRecentLimit() {
       // Ensure limit is within bounds
       if (this.recentLimit < 1) this.recentLimit = 1;
-      if (this.recentLimit > 50) this.recentLimit = 50;
+      if (this.recentLimit > 100) this.recentLimit = 100;
       
       localStorage.setItem('plexRecentLimit', this.recentLimit);
       this.$emit('limitChanged', this.recentLimit);

--- a/src/components/PlexConnection.vue
+++ b/src/components/PlexConnection.vue
@@ -1,0 +1,371 @@
+<template>
+  <div class="plex-connection">
+    <h2>Connect to Plex</h2>
+    
+    <form @submit.prevent="connect">
+      <div class="form-group">
+        <label for="baseUrl">Plex URL:</label>
+        <input 
+          id="baseUrl" 
+          v-model="baseUrl" 
+          type="text" 
+          placeholder="http://localhost:32400"
+          required
+        />
+        <p class="help-text">Enter your Plex server address, including port (usually 32400)</p>
+      </div>
+      
+      <div class="form-group">
+        <label for="token">Plex Token:</label>
+        <input 
+          id="token" 
+          v-model="token" 
+          type="password" 
+          placeholder="Your Plex token"
+          required
+        />
+        <p class="help-text">Your Plex authentication token - <a href="https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/" target="_blank">How to find your Plex token</a></p>
+      </div>
+      
+      <button type="submit" :disabled="connecting">
+        {{ connecting ? 'Connecting...' : 'Connect' }}
+      </button>
+    </form>
+    
+    <div v-if="connectionStatus" class="connection-status">
+      <p v-if="connectionStatus === 'success'" class="success">
+        Connected successfully!
+      </p>
+      <p v-else-if="connectionStatus === 'error'" class="error">
+        Connection failed. Please check your URL and token.
+      </p>
+    </div>
+
+    <div v-if="connectionStatus === 'success'" class="recently-watched-options">
+      <h3>Recently Watched Options</h3>
+      
+      <div class="form-group">
+        <label for="recentLimit">Number of recently watched items to include:</label>
+        <div class="limit-control">
+          <input 
+            id="recentLimit" 
+            v-model.number="recentLimit" 
+            type="number" 
+            min="1" 
+            max="50" 
+            @change="saveRecentLimit"
+          />
+          <div class="limit-buttons">
+            <button type="button" @click="decreaseLimit" class="limit-btn">-</button>
+            <button type="button" @click="increaseLimit" class="limit-btn">+</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import plexService from '../services/PlexService';
+
+export default {
+  name: 'PlexConnection',
+  data() {
+    return {
+      baseUrl: '',
+      token: '',
+      connectionStatus: null,
+      connecting: false,
+      recentLimit: 10 // Default limit for recently watched items
+    };
+  },
+  created() {
+    // Load saved credentials if they exist
+    const savedBaseUrl = localStorage.getItem('plexBaseUrl');
+    const savedToken = localStorage.getItem('plexToken');
+    const savedRecentLimit = localStorage.getItem('plexRecentLimit');
+    
+    if (savedBaseUrl && savedToken) {
+      this.baseUrl = savedBaseUrl;
+      this.token = savedToken;
+      // Try to automatically connect with saved credentials
+      this.autoConnect();
+    }
+
+    if (savedRecentLimit) {
+      this.recentLimit = parseInt(savedRecentLimit, 10);
+      // Validate the value is within range
+      if (isNaN(this.recentLimit) || this.recentLimit < 1) {
+        this.recentLimit = 5;
+      } else if (this.recentLimit > 50) {
+        this.recentLimit = 50;
+      }
+    }
+  },
+  methods: {
+    async autoConnect() {
+      this.connecting = true;
+      
+      try {
+        // Validate and normalize the URL
+        if (!this.validateUrl()) {
+          // Clear invalid credentials
+          this.clearStoredCredentials();
+          return;
+        }
+        
+        // Configure the service with saved details
+        plexService.configure(this.baseUrl, this.token);
+        
+        // Test the connection
+        const success = await plexService.testConnection();
+        
+        // Only emit event if successful
+        if (success) {
+          // Update the URL in case it was normalized
+          this.saveCredentials();
+          this.connectionStatus = 'success';
+          this.$emit('connected');
+        } else {
+          // Clear invalid credentials
+          this.clearStoredCredentials();
+        }
+      } catch (error) {
+        console.error('Error auto-connecting to Plex:', error);
+        // Clear invalid credentials
+        this.clearStoredCredentials();
+      } finally {
+        this.connecting = false;
+      }
+    },
+    async connect() {
+      this.connecting = true;
+      this.connectionStatus = null;
+      
+      try {
+        // Validate and normalize the URL
+        if (!this.validateUrl()) {
+          this.connectionStatus = 'error';
+          return;
+        }
+        
+        // Configure the service with provided details
+        plexService.configure(this.baseUrl, this.token);
+        
+        // Test the connection
+        const success = await plexService.testConnection();
+        
+        // Update status based on response
+        this.connectionStatus = success ? 'success' : 'error';
+        
+        // If successful, save credentials and emit event
+        if (success) {
+          this.saveCredentials();
+          this.$emit('connected');
+        }
+      } catch (error) {
+        console.error('Error connecting to Plex:', error);
+        this.connectionStatus = 'error';
+      } finally {
+        this.connecting = false;
+      }
+    },
+    
+    validateUrl() {
+      try {
+        // Validate URL format
+        if (!this.baseUrl) {
+          return false;
+        }
+        
+        // Make sure URL starts with http:// or https://
+        if (!this.baseUrl.match(/^https?:\/\//)) {
+          this.baseUrl = 'http://' + this.baseUrl;
+        }
+        
+        // Normalize URL by removing trailing slashes
+        this.baseUrl = this.baseUrl.replace(/\/+$/, '');
+        
+        // Basic validation that it looks like a URL
+        new URL(this.baseUrl);
+        return true;
+      } catch (e) {
+        console.error('Invalid URL format:', e);
+        return false;
+      }
+    },
+    
+    saveCredentials() {
+      localStorage.setItem('plexBaseUrl', this.baseUrl);
+      localStorage.setItem('plexToken', this.token);
+    },
+    clearStoredCredentials() {
+      localStorage.removeItem('plexBaseUrl');
+      localStorage.removeItem('plexToken');
+    },
+    increaseLimit() {
+      if (this.recentLimit < 50) {
+        this.recentLimit++;
+        this.saveRecentLimit();
+      }
+    },
+    decreaseLimit() {
+      if (this.recentLimit > 1) {
+        this.recentLimit--;
+        this.saveRecentLimit();
+      }
+    },
+    saveRecentLimit() {
+      // Ensure limit is within bounds
+      if (this.recentLimit < 1) this.recentLimit = 1;
+      if (this.recentLimit > 50) this.recentLimit = 50;
+      
+      localStorage.setItem('plexRecentLimit', this.recentLimit);
+      this.$emit('limitChanged', this.recentLimit);
+    }
+  }
+};
+</script>
+
+<style scoped>
+.plex-connection {
+  max-width: 500px;
+  margin: 0 auto;
+  padding: 20px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background-color: var(--card-bg-color);
+  box-shadow: var(--card-shadow);
+  transition: background-color var(--transition-speed), 
+              border-color var(--transition-speed),
+              box-shadow var(--transition-speed);
+}
+
+h2, h3 {
+  color: var(--header-color);
+  transition: color var(--transition-speed);
+}
+
+h2 {
+  margin-top: 0;
+}
+
+h3 {
+  font-size: 1.2em;
+  margin-top: 20px;
+  margin-bottom: 15px;
+  padding-top: 15px;
+  border-top: 1px solid var(--border-color);
+}
+
+.form-group {
+  margin-bottom: 15px;
+}
+
+label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: bold;
+  color: var(--text-color);
+  transition: color var(--transition-speed);
+}
+
+input {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid var(--input-border);
+  border-radius: 4px;
+  box-sizing: border-box;
+  background-color: var(--input-bg);
+  color: var(--input-text);
+  transition: background-color var(--transition-speed), 
+              border-color var(--transition-speed),
+              color var(--transition-speed);
+}
+
+input[type="number"] {
+  width: 60px;
+  text-align: center;
+}
+
+.help-text {
+  font-size: 12px;
+  margin-top: 5px;
+  color: var(--text-muted);
+  transition: color var(--transition-speed);
+}
+
+.help-text a {
+  color: var(--button-primary-bg);
+  text-decoration: none;
+}
+
+.help-text a:hover {
+  text-decoration: underline;
+}
+
+button {
+  background-color: var(--button-primary-bg);
+  color: var(--button-primary-text);
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: background-color var(--transition-speed), 
+              color var(--transition-speed),
+              filter 0.2s;
+}
+
+button:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.connection-status {
+  margin-top: 15px;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+.success {
+  color: var(--button-primary-bg);
+  transition: color var(--transition-speed);
+}
+
+.error {
+  color: #f44336;
+  transition: color var(--transition-speed);
+}
+
+.limit-control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.limit-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.limit-btn {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 14px;
+}
+
+.recently-watched-options {
+  margin-top: 15px;
+}
+</style>

--- a/src/components/RadarrConnection.vue
+++ b/src/components/RadarrConnection.vue
@@ -20,7 +20,7 @@
           id="apiKey" 
           v-model="apiKey" 
           type="password" 
-          placeholder="Your Sonarr API key"
+          placeholder="Your Radarr API key"
           required
         />
       </div>

--- a/src/components/TVRecommendations.vue
+++ b/src/components/TVRecommendations.vue
@@ -152,6 +152,41 @@
                     </div>
                   </div>
                 </div>
+                
+                <div v-if="plexConfigured" class="plex-options">
+                  <label>Plex Watch History:</label>
+                  <div class="plex-history-toggle">
+                    <label class="toggle-option">
+                      <input 
+                        type="radio" 
+                        v-model="plexHistoryMode" 
+                        value="all"
+                        @change="savePlexHistoryMode"
+                      >
+                      All watch history
+                    </label>
+                    <label class="toggle-option">
+                      <input 
+                        type="radio" 
+                        v-model="plexHistoryMode" 
+                        value="recent"
+                        @change="savePlexHistoryMode"
+                      >
+                      Recent (30 days)
+                    </label>
+                  </div>
+                  
+                  <div class="plex-only-toggle">
+                    <label class="checkbox-label">
+                      <input 
+                        type="checkbox" 
+                        v-model="plexOnlyMode" 
+                        @change="savePlexOnlyMode"
+                      >
+                      Use only Plex history for recommendations (ignore library)
+                    </label>
+                  </div>
+                </div>
               </div>
             </div>
             
@@ -405,7 +440,9 @@ export default {
       loadingPosters: new Map(), // Track which posters are being loaded
       numRecommendations: 5, // Default number of recommendations to request
       columnsCount: 2, // Default number of posters per row
-      selectedGenres: [], // Multiple genre selections 
+      selectedGenres: [], // Multiple genre selections
+      plexHistoryMode: 'all', // 'all' or 'recent'
+      plexOnlyMode: false, // Whether to use only Plex history for recommendations
       availableGenres: [
         { value: 'action', label: 'Action' },
         { value: 'adventure', label: 'Adventure' },
@@ -637,6 +674,18 @@ export default {
       this.saveGenrePreference();
     },
     
+    // Save Plex history mode preference
+    savePlexHistoryMode() {
+      localStorage.setItem('plexHistoryMode', this.plexHistoryMode);
+      this.$emit('plexHistoryModeChanged', this.plexHistoryMode);
+    },
+    
+    // Save Plex only mode preference
+    savePlexOnlyMode() {
+      localStorage.setItem('plexOnlyMode', this.plexOnlyMode.toString());
+      this.$emit('plexOnlyModeChanged', this.plexOnlyMode);
+    },
+    
     // Save previous recommendations to localStorage
     savePreviousRecommendations() {
       localStorage.setItem('previousTVRecommendations', JSON.stringify(this.previousRecommendations));
@@ -864,7 +913,8 @@ export default {
           this.previousRecommendations,
           this.likedRecommendations,
           this.dislikedRecommendations,
-          this.recentlyWatchedShows
+          this.recentlyWatchedShows,
+          this.plexOnlyMode
         );
         
         // Update loading message to include genres if selected
@@ -1162,6 +1212,18 @@ export default {
         console.error('Error parsing saved genres:', error);
         this.selectedGenres = [];
       }
+    }
+    
+    // Restore saved Plex history mode if it exists
+    const savedPlexHistoryMode = localStorage.getItem('plexHistoryMode');
+    if (savedPlexHistoryMode) {
+      this.plexHistoryMode = savedPlexHistoryMode;
+    }
+    
+    // Restore saved Plex only mode if it exists
+    const savedPlexOnlyMode = localStorage.getItem('plexOnlyMode');
+    if (savedPlexOnlyMode) {
+      this.plexOnlyMode = savedPlexOnlyMode === 'true';
     }
     
     // Load previous TV recommendations from localStorage
@@ -2408,6 +2470,39 @@ select:hover {
   color: var(--text-color);
   opacity: 0.7;
   transition: color var(--transition-speed);
+}
+
+.plex-options {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: rgba(0, 0, 0, 0.02);
+  border-radius: 8px;
+}
+
+.plex-history-toggle {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.toggle-option {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  margin: 0;
+  font-size: 14px;
+}
+
+.toggle-option input[type="radio"] {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+.plex-only-toggle {
+  margin-top: 15px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
 }
 
 .request-button {

--- a/src/components/TVRecommendations.vue
+++ b/src/components/TVRecommendations.vue
@@ -171,7 +171,7 @@
       
       <div v-if="loading" class="loading">
         <div class="spinner"></div>
-        <p>Analyzing your TV show library and generating recommendations...</p>
+        <p>{{ plexConfigured ? 'Analyzing your TV show library and Plex watch history...' : 'Analyzing your TV show library and generating recommendations...' }}</p>
       </div>
       
       <div v-else-if="error" class="error">
@@ -373,6 +373,14 @@ export default {
     sonarrConfigured: {
       type: Boolean,
       required: true
+    },
+    recentlyWatchedShows: {
+      type: Array,
+      default: () => []
+    },
+    plexConfigured: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
@@ -848,13 +856,15 @@ export default {
           : '';
         
         // Pass the previous recommendations to be excluded and liked/disliked lists
+        // Include recently watched shows from Plex if available
         this.recommendations = await openAIService.getRecommendations(
           this.series, 
           this.numRecommendations,
           genreString,
           this.previousRecommendations,
           this.likedRecommendations,
-          this.dislikedRecommendations
+          this.dislikedRecommendations,
+          this.recentlyWatchedShows
         );
         
         // Update loading message to include genres if selected

--- a/src/components/TVRecommendations.vue
+++ b/src/components/TVRecommendations.vue
@@ -206,7 +206,7 @@
       
       <div v-if="loading" class="loading">
         <div class="spinner"></div>
-        <p>{{ plexConfigured ? 'Analyzing your TV show library and Plex watch history...' : 'Analyzing your TV show library and generating recommendations...' }}</p>
+        <p>{{ plexOnlyMode ? 'Analyzing your Plex watch history...' : (plexConfigured ? 'Analyzing your TV show library and Plex watch history...' : 'Analyzing your TV show library and generating recommendations...') }}</p>
       </div>
       
       <div v-else-if="error" class="error">
@@ -920,7 +920,8 @@ export default {
         // Update loading message to include genres if selected
         const loadingMessage = document.querySelector('.loading p');
         if (loadingMessage && this.selectedGenres.length > 0) {
-          loadingMessage.textContent = `Analyzing your TV library and generating ${genreString} recommendations...`;
+          const source = this.plexOnlyMode ? 'Plex watch history' : 'TV library';
+          loadingMessage.textContent = `Analyzing your ${source} and generating ${genreString} recommendations...`;
         }
         
         // Add new recommendations to history

--- a/src/services/OpenAIService.js
+++ b/src/services/OpenAIService.js
@@ -113,6 +113,9 @@ class OpenAIService {
       if (recentlyWatchedShows && recentlyWatchedShows.length > 0) {
         const recentShowTitles = recentlyWatchedShows.map(show => show.title).join(', ');
         userPrompt += `\n\nI've recently watched these shows on Plex, so please consider them for better recommendations: ${recentShowTitles}`;
+        console.log('Adding recently watched shows to prompt:', recentShowTitles);
+      } else {
+        console.log('No recently watched shows to add to prompt');
       }
       
       userPrompt += `\n\nFormat each recommendation EXACTLY as follows (using the exact section titles):
@@ -204,6 +207,9 @@ My current shows: ${allShowTitles}`;
       if (recentlyWatchedMovies && recentlyWatchedMovies.length > 0) {
         const recentMovieTitles = recentlyWatchedMovies.map(movie => movie.title).join(', ');
         userPrompt += `\n\nI've recently watched these movies on Plex, so please consider them for better recommendations: ${recentMovieTitles}`;
+        console.log('Adding recently watched movies to prompt:', recentMovieTitles);
+      } else {
+        console.log('No recently watched movies to add to prompt');
       }
       
       userPrompt += `\n\nFormat each recommendation EXACTLY as follows (using the exact section titles):

--- a/src/services/OpenAIService.js
+++ b/src/services/OpenAIService.js
@@ -70,27 +70,36 @@ class OpenAIService {
    * @param {Array} [likedRecommendations=[]] - List of shows the user has liked
    * @param {Array} [dislikedRecommendations=[]] - List of shows the user has disliked
    * @param {Array} [recentlyWatchedShows=[]] - List of recently watched shows from Plex
+   * @param {boolean} [plexOnlyMode=false] - Whether to use only Plex history for recommendations
    * @returns {Promise<Array>} - List of recommended TV shows
    */
-  async getRecommendations(series, count = 5, genre = '', previousRecommendations = [], likedRecommendations = [], dislikedRecommendations = [], recentlyWatchedShows = []) {
+  async getRecommendations(series, count = 5, genre = '', previousRecommendations = [], likedRecommendations = [], dislikedRecommendations = [], recentlyWatchedShows = [], plexOnlyMode = false) {
     if (!this.isConfigured()) {
       throw new Error('OpenAI service is not configured. Please set apiKey.');
     }
 
     try {
-      // Only extract show titles to minimize token usage
-      const showTitles = series.map(show => show.title).join(', ');
+      // Determine if we should use only Plex history or include the library
+      let sourceText, sourceLibrary;
       
-      // Add liked shows to the current library for the AI to consider
-      const allShowTitles = likedRecommendations.length > 0 
-        ? `${showTitles}, ${likedRecommendations.join(', ')}`
-        : showTitles;
+      if (plexOnlyMode && recentlyWatchedShows && recentlyWatchedShows.length > 0) {
+        // Only use the Plex watch history
+        sourceText = "my Plex watch history";
+        sourceLibrary = recentlyWatchedShows.map(show => show.title).join(', ');
+      } else {
+        // Use the Sonarr library + liked shows as the main library
+        sourceText = "my TV show library";
+        const showTitles = series.map(show => show.title).join(', ');
+        sourceLibrary = likedRecommendations.length > 0 
+          ? `${showTitles}, ${likedRecommendations.join(', ')}`
+          : showTitles;
+      }
       
       // Ensure count is within reasonable bounds
       const recommendationCount = Math.min(Math.max(count, 1), 50);
 
       // Base prompt
-      let userPrompt = `Based on my TV show library, recommend ${recommendationCount} new shows I might enjoy. Be brief and direct - no more than 2-3 sentences per section.`;
+      let userPrompt = `Based on ${sourceText}, recommend ${recommendationCount} new shows I might enjoy. Be brief and direct - no more than 2-3 sentences per section.`;
       
       // Add genre preference if specified
       if (genre) {
@@ -109,12 +118,12 @@ class OpenAIService {
         userPrompt += `\n\nI specifically dislike these shows, so don't recommend anything too similar: ${dislikedRecommendations.join(', ')}`;
       }
       
-      // Add recently watched shows from Plex if available
-      if (recentlyWatchedShows && recentlyWatchedShows.length > 0) {
+      // Add recently watched shows from Plex if available and not already using them as the primary source
+      if (!plexOnlyMode && recentlyWatchedShows && recentlyWatchedShows.length > 0) {
         const recentShowTitles = recentlyWatchedShows.map(show => show.title).join(', ');
         userPrompt += `\n\nI've recently watched these shows on Plex, so please consider them for better recommendations: ${recentShowTitles}`;
         console.log('Adding recently watched shows to prompt:', recentShowTitles);
-      } else {
+      } else if (!recentlyWatchedShows || recentlyWatchedShows.length === 0) {
         console.log('No recently watched shows to add to prompt');
       }
       
@@ -135,7 +144,7 @@ DO NOT mention or cite any specific external rating sources or scores in your ex
 
 Do not add extra text, headings, or any formatting. Only use each section title (Description, Why you might like it, Recommendarr Rating, Available on) exactly once per show.
 
-My current shows: ${allShowTitles}`;
+My current shows: ${sourceLibrary}`;
 
       const messages = [
         {
@@ -164,27 +173,36 @@ My current shows: ${allShowTitles}`;
    * @param {Array} [likedRecommendations=[]] - List of movies the user has liked
    * @param {Array} [dislikedRecommendations=[]] - List of movies the user has disliked
    * @param {Array} [recentlyWatchedMovies=[]] - List of recently watched movies from Plex
+   * @param {boolean} [plexOnlyMode=false] - Whether to use only Plex history for recommendations
    * @returns {Promise<Array>} - List of recommended movies
    */
-  async getMovieRecommendations(movies, count = 5, genre = '', previousRecommendations = [], likedRecommendations = [], dislikedRecommendations = [], recentlyWatchedMovies = []) {
+  async getMovieRecommendations(movies, count = 5, genre = '', previousRecommendations = [], likedRecommendations = [], dislikedRecommendations = [], recentlyWatchedMovies = [], plexOnlyMode = false) {
     if (!this.isConfigured()) {
       throw new Error('OpenAI service is not configured. Please set apiKey.');
     }
 
     try {
-      // Only extract movie titles to minimize token usage
-      const movieTitles = movies.map(movie => movie.title).join(', ');
+      // Determine if we should use only Plex history or include the library
+      let sourceText, sourceLibrary;
       
-      // Add liked movies to the current library for the AI to consider
-      const allMovieTitles = likedRecommendations.length > 0 
-        ? `${movieTitles}, ${likedRecommendations.join(', ')}`
-        : movieTitles;
+      if (plexOnlyMode && recentlyWatchedMovies && recentlyWatchedMovies.length > 0) {
+        // Only use the Plex watch history
+        sourceText = "my Plex watch history";
+        sourceLibrary = recentlyWatchedMovies.map(movie => movie.title).join(', ');
+      } else {
+        // Use the Radarr library + liked movies as the main library
+        sourceText = "my movie library";
+        const movieTitles = movies.map(movie => movie.title).join(', ');
+        sourceLibrary = likedRecommendations.length > 0 
+          ? `${movieTitles}, ${likedRecommendations.join(', ')}`
+          : movieTitles;
+      }
       
       // Ensure count is within reasonable bounds
       const recommendationCount = Math.min(Math.max(count, 1), 50);
       
       // Base prompt
-      let userPrompt = `Based on my movie library, recommend ${recommendationCount} new movies I might enjoy. Be brief and direct - no more than 2-3 sentences per section.`;
+      let userPrompt = `Based on ${sourceText}, recommend ${recommendationCount} new movies I might enjoy. Be brief and direct - no more than 2-3 sentences per section.`;
       
       // Add genre preference if specified
       if (genre) {
@@ -203,12 +221,12 @@ My current shows: ${allShowTitles}`;
         userPrompt += `\n\nI specifically dislike these movies, so don't recommend anything too similar: ${dislikedRecommendations.join(', ')}`;
       }
       
-      // Add recently watched movies from Plex if available
-      if (recentlyWatchedMovies && recentlyWatchedMovies.length > 0) {
+      // Add recently watched movies from Plex if available and not already using them as the primary source
+      if (!plexOnlyMode && recentlyWatchedMovies && recentlyWatchedMovies.length > 0) {
         const recentMovieTitles = recentlyWatchedMovies.map(movie => movie.title).join(', ');
         userPrompt += `\n\nI've recently watched these movies on Plex, so please consider them for better recommendations: ${recentMovieTitles}`;
         console.log('Adding recently watched movies to prompt:', recentMovieTitles);
-      } else {
+      } else if (!recentlyWatchedMovies || recentlyWatchedMovies.length === 0) {
         console.log('No recently watched movies to add to prompt');
       }
       
@@ -229,7 +247,7 @@ DO NOT mention or cite any specific external rating sources or scores in your ex
 
 Do not add extra text, headings, or any formatting. Only use each section title (Description, Why you might like it, Recommendarr Rating, Available on) exactly once per movie.
 
-My current movies: ${allMovieTitles}`;
+My current movies: ${sourceLibrary}`;
 
       const messages = [
         {

--- a/src/services/OpenAIService.js
+++ b/src/services/OpenAIService.js
@@ -69,9 +69,10 @@ class OpenAIService {
    * @param {Array} [previousRecommendations=[]] - List of shows to exclude from recommendations
    * @param {Array} [likedRecommendations=[]] - List of shows the user has liked
    * @param {Array} [dislikedRecommendations=[]] - List of shows the user has disliked
+   * @param {Array} [recentlyWatchedShows=[]] - List of recently watched shows from Plex
    * @returns {Promise<Array>} - List of recommended TV shows
    */
-  async getRecommendations(series, count = 5, genre = '', previousRecommendations = [], likedRecommendations = [], dislikedRecommendations = []) {
+  async getRecommendations(series, count = 5, genre = '', previousRecommendations = [], likedRecommendations = [], dislikedRecommendations = [], recentlyWatchedShows = []) {
     if (!this.isConfigured()) {
       throw new Error('OpenAI service is not configured. Please set apiKey.');
     }
@@ -108,6 +109,12 @@ class OpenAIService {
         userPrompt += `\n\nI specifically dislike these shows, so don't recommend anything too similar: ${dislikedRecommendations.join(', ')}`;
       }
       
+      // Add recently watched shows from Plex if available
+      if (recentlyWatchedShows && recentlyWatchedShows.length > 0) {
+        const recentShowTitles = recentlyWatchedShows.map(show => show.title).join(', ');
+        userPrompt += `\n\nI've recently watched these shows on Plex, so please consider them for better recommendations: ${recentShowTitles}`;
+      }
+      
       userPrompt += `\n\nFormat each recommendation EXACTLY as follows (using the exact section titles):
 1. [Show Title]: 
 Description: [brief description] 
@@ -130,7 +137,7 @@ My current shows: ${allShowTitles}`;
       const messages = [
         {
           role: "system",
-          content: "You are a TV show recommendation assistant. Your task is to recommend new TV shows based on the user's current library. Be concise and to the point. Do not use any Markdown formatting like ** for bold or * for italic. You MUST use the exact format requested."
+          content: "You are a TV show recommendation assistant. Your task is to recommend new TV shows based on the user's current library and recently watched content. Be concise and to the point. Do not use any Markdown formatting like ** for bold or * for italic. You MUST use the exact format requested."
         },
         {
           role: "user",
@@ -153,9 +160,10 @@ My current shows: ${allShowTitles}`;
    * @param {Array} [previousRecommendations=[]] - List of movies to exclude from recommendations
    * @param {Array} [likedRecommendations=[]] - List of movies the user has liked
    * @param {Array} [dislikedRecommendations=[]] - List of movies the user has disliked
+   * @param {Array} [recentlyWatchedMovies=[]] - List of recently watched movies from Plex
    * @returns {Promise<Array>} - List of recommended movies
    */
-  async getMovieRecommendations(movies, count = 5, genre = '', previousRecommendations = [], likedRecommendations = [], dislikedRecommendations = []) {
+  async getMovieRecommendations(movies, count = 5, genre = '', previousRecommendations = [], likedRecommendations = [], dislikedRecommendations = [], recentlyWatchedMovies = []) {
     if (!this.isConfigured()) {
       throw new Error('OpenAI service is not configured. Please set apiKey.');
     }
@@ -192,6 +200,12 @@ My current shows: ${allShowTitles}`;
         userPrompt += `\n\nI specifically dislike these movies, so don't recommend anything too similar: ${dislikedRecommendations.join(', ')}`;
       }
       
+      // Add recently watched movies from Plex if available
+      if (recentlyWatchedMovies && recentlyWatchedMovies.length > 0) {
+        const recentMovieTitles = recentlyWatchedMovies.map(movie => movie.title).join(', ');
+        userPrompt += `\n\nI've recently watched these movies on Plex, so please consider them for better recommendations: ${recentMovieTitles}`;
+      }
+      
       userPrompt += `\n\nFormat each recommendation EXACTLY as follows (using the exact section titles):
 1. [Movie Title]: 
 Description: [brief description] 
@@ -214,7 +228,7 @@ My current movies: ${allMovieTitles}`;
       const messages = [
         {
           role: "system",
-          content: "You are a movie recommendation assistant. Your task is to recommend new movies based on the user's current library. Be concise and to the point. Do not use any Markdown formatting like ** for bold or * for italic. You MUST use the exact format requested."
+          content: "You are a movie recommendation assistant. Your task is to recommend new movies based on the user's current library and recently watched content. Be concise and to the point. Do not use any Markdown formatting like ** for bold or * for italic. You MUST use the exact format requested."
         },
         {
           role: "user",

--- a/src/services/OpenAIService.js
+++ b/src/services/OpenAIService.js
@@ -86,6 +86,12 @@ class OpenAIService {
         // Only use the Plex watch history
         sourceText = "my Plex watch history";
         sourceLibrary = recentlyWatchedShows.map(show => show.title).join(', ');
+        
+        // Add library titles to exclusions to prevent recommending what user already has
+        if (series && series.length > 0) {
+          const libraryTitles = series.map(show => show.title);
+          previousRecommendations = [...new Set([...previousRecommendations, ...libraryTitles])];
+        }
       } else {
         // Use the Sonarr library + liked shows as the main library
         sourceText = "my TV show library";
@@ -189,6 +195,12 @@ My current shows: ${sourceLibrary}`;
         // Only use the Plex watch history
         sourceText = "my Plex watch history";
         sourceLibrary = recentlyWatchedMovies.map(movie => movie.title).join(', ');
+        
+        // Add library titles to exclusions to prevent recommending what user already has
+        if (movies && movies.length > 0) {
+          const libraryTitles = movies.map(movie => movie.title);
+          previousRecommendations = [...new Set([...previousRecommendations, ...libraryTitles])];
+        }
       } else {
         // Use the Radarr library + liked movies as the main library
         sourceText = "my movie library";

--- a/src/services/PlexService.js
+++ b/src/services/PlexService.js
@@ -1,0 +1,154 @@
+import axios from 'axios';
+
+class PlexService {
+  constructor() {
+    // Try to restore from localStorage on initialization
+    this.token = localStorage.getItem('plexToken') || '';
+    this.baseUrl = localStorage.getItem('plexBaseUrl') || '';
+  }
+
+  /**
+   * Configure the Plex service with API details
+   * @param {string} baseUrl - The base URL of your Plex instance (e.g., http://localhost:32400)
+   * @param {string} token - Your Plex token
+   */
+  configure(baseUrl, token) {
+    // Normalize the URL by removing trailing slashes
+    this.baseUrl = baseUrl ? baseUrl.replace(/\/+$/, '') : '';
+    this.token = token;
+  }
+
+  /**
+   * Check if the service is configured with token and URL
+   * @returns {boolean} - Whether the service is configured
+   */
+  isConfigured() {
+    return this.token && this.baseUrl;
+  }
+
+  /**
+   * Test the connection to Plex
+   * @returns {Promise<boolean>} - Whether the connection is successful
+   */
+  async testConnection() {
+    if (!this.isConfigured()) {
+      throw new Error('Plex service is not configured. Please set baseUrl and token.');
+    }
+
+    try {
+      const response = await axios.get(`${this.baseUrl}/identity`, {
+        params: { 
+          'X-Plex-Token': this.token 
+        }
+      });
+      return response.status === 200;
+    } catch (error) {
+      console.error('Error connecting to Plex:', error);
+      return false;
+    }
+  }
+
+  /**
+   * Get recently watched movies from Plex
+   * @param {number} limit - Maximum number of items to return
+   * @returns {Promise<Array>} - List of recently watched movies
+   */
+  async getRecentlyWatchedMovies(limit = 20) {
+    if (!this.isConfigured()) {
+      throw new Error('Plex service is not configured. Please set baseUrl and token.');
+    }
+
+    try {
+      // Get recently watched from the history endpoint
+      const response = await axios.get(`${this.baseUrl}/status/sessions/history/all`, {
+        params: {
+          'X-Plex-Token': this.token,
+          'type': 1, // Type 1 is movie
+          'sort': 'viewedAt:desc',
+          'limit': limit
+        }
+      });
+
+      // Parse the XML response
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(response.data, "text/xml");
+      const videoNodes = xmlDoc.querySelectorAll('Video');
+      
+      // Extract movie info from XML
+      const movies = Array.from(videoNodes).map(node => {
+        return {
+          title: node.getAttribute('title'),
+          year: node.getAttribute('year'),
+          viewedAt: node.getAttribute('viewedAt'),
+          ratingKey: node.getAttribute('ratingKey')
+        };
+      });
+
+      // Filter duplicates by title
+      const uniqueMovies = movies.filter((movie, index, self) => 
+        index === self.findIndex((m) => m.title === movie.title)
+      );
+
+      return uniqueMovies;
+    } catch (error) {
+      console.error('Error fetching recently watched movies from Plex:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get recently watched TV shows from Plex
+   * @param {number} limit - Maximum number of items to return
+   * @returns {Promise<Array>} - List of recently watched TV shows
+   */
+  async getRecentlyWatchedShows(limit = 20) {
+    if (!this.isConfigured()) {
+      throw new Error('Plex service is not configured. Please set baseUrl and token.');
+    }
+
+    try {
+      // Get recently watched from the history endpoint
+      const response = await axios.get(`${this.baseUrl}/status/sessions/history/all`, {
+        params: {
+          'X-Plex-Token': this.token,
+          'type': 4, // Type 4 is TV episode
+          'sort': 'viewedAt:desc',
+          'limit': limit
+        }
+      });
+
+      // Parse the XML response
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(response.data, "text/xml");
+      const episodeNodes = xmlDoc.querySelectorAll('Video');
+      
+      // Extract show info from XML (grouping by show)
+      const showMap = new Map();
+      
+      Array.from(episodeNodes).forEach(node => {
+        const grandparentTitle = node.getAttribute('grandparentTitle'); // Show title
+        if (grandparentTitle) {
+          if (!showMap.has(grandparentTitle)) {
+            showMap.set(grandparentTitle, {
+              title: grandparentTitle,
+              year: node.getAttribute('parentYear') || node.getAttribute('year'),
+              viewedAt: node.getAttribute('viewedAt'),
+              ratingKey: node.getAttribute('grandparentRatingKey')
+            });
+          }
+        }
+      });
+
+      // Convert map to array
+      return Array.from(showMap.values());
+    } catch (error) {
+      console.error('Error fetching recently watched shows from Plex:', error);
+      throw error;
+    }
+  }
+}
+
+// Create a singleton instance
+const plexService = new PlexService();
+
+export default plexService;

--- a/src/services/PlexService.js
+++ b/src/services/PlexService.js
@@ -74,6 +74,8 @@ class PlexService {
       const xmlDoc = parser.parseFromString(response.data, "text/xml");
       const videoNodes = xmlDoc.querySelectorAll('Video');
       
+      console.log(`Found ${videoNodes.length} recently watched movies in Plex history`);
+      
       // Extract movie info from XML
       const movies = Array.from(videoNodes).map(node => {
         return {
@@ -89,6 +91,7 @@ class PlexService {
         index === self.findIndex((m) => m.title === movie.title)
       );
 
+      console.log(`Returning ${uniqueMovies.length} unique recently watched movies`);
       return uniqueMovies;
     } catch (error) {
       console.error('Error fetching recently watched movies from Plex:', error);
@@ -122,6 +125,8 @@ class PlexService {
       const xmlDoc = parser.parseFromString(response.data, "text/xml");
       const episodeNodes = xmlDoc.querySelectorAll('Video');
       
+      console.log(`Found ${episodeNodes.length} recently watched TV episodes in Plex history`);
+      
       // Extract show info from XML (grouping by show)
       const showMap = new Map();
       
@@ -140,7 +145,9 @@ class PlexService {
       });
 
       // Convert map to array
-      return Array.from(showMap.values());
+      const shows = Array.from(showMap.values());
+      console.log(`Returning ${shows.length} unique recently watched TV shows`);
+      return shows;
     } catch (error) {
       console.error('Error fetching recently watched shows from Plex:', error);
       throw error;

--- a/src/services/PlexService.js
+++ b/src/services/PlexService.js
@@ -51,22 +51,37 @@ class PlexService {
   /**
    * Get recently watched movies from Plex
    * @param {number} limit - Maximum number of items to return
+   * @param {number} [daysAgo=0] - Only include movies watched within this many days (0 for all)
    * @returns {Promise<Array>} - List of recently watched movies
    */
-  async getRecentlyWatchedMovies(limit = 20) {
+  async getRecentlyWatchedMovies(limit = 100, daysAgo = 0) {
     if (!this.isConfigured()) {
       throw new Error('Plex service is not configured. Please set baseUrl and token.');
     }
 
     try {
+      // Build params object
+      const params = {
+        'X-Plex-Token': this.token,
+        'type': 1, // Type 1 is movie
+        'sort': 'viewedAt:desc',
+        'limit': limit
+      };
+      
+      // Add viewedAt filter if daysAgo is specified
+      if (daysAgo > 0) {
+        // Calculate timestamp for X days ago (in seconds, Plex API uses seconds not milliseconds)
+        const nowInSeconds = Math.floor(Date.now() / 1000);
+        const daysAgoInSeconds = daysAgo * 24 * 60 * 60;
+        const timestampFilter = nowInSeconds - daysAgoInSeconds;
+        
+        // Add filter to only include items watched after this timestamp
+        params['viewedAt>'] = timestampFilter;
+      }
+      
       // Get recently watched from the history endpoint
       const response = await axios.get(`${this.baseUrl}/status/sessions/history/all`, {
-        params: {
-          'X-Plex-Token': this.token,
-          'type': 1, // Type 1 is movie
-          'sort': 'viewedAt:desc',
-          'limit': limit
-        }
+        params: params
       });
 
       // Log response type and structure for debugging
@@ -182,22 +197,37 @@ class PlexService {
   /**
    * Get recently watched TV shows from Plex
    * @param {number} limit - Maximum number of items to return
+   * @param {number} [daysAgo=0] - Only include shows watched within this many days (0 for all)
    * @returns {Promise<Array>} - List of recently watched TV shows
    */
-  async getRecentlyWatchedShows(limit = 20) {
+  async getRecentlyWatchedShows(limit = 100, daysAgo = 0) {
     if (!this.isConfigured()) {
       throw new Error('Plex service is not configured. Please set baseUrl and token.');
     }
 
     try {
+      // Build params object
+      const params = {
+        'X-Plex-Token': this.token,
+        'type': 4, // Type 4 is TV episode
+        'sort': 'viewedAt:desc',
+        'limit': limit
+      };
+      
+      // Add viewedAt filter if daysAgo is specified
+      if (daysAgo > 0) {
+        // Calculate timestamp for X days ago (in seconds, Plex API uses seconds not milliseconds)
+        const nowInSeconds = Math.floor(Date.now() / 1000);
+        const daysAgoInSeconds = daysAgo * 24 * 60 * 60;
+        const timestampFilter = nowInSeconds - daysAgoInSeconds;
+        
+        // Add filter to only include items watched after this timestamp
+        params['viewedAt>'] = timestampFilter;
+      }
+      
       // Get recently watched from the history endpoint
       const response = await axios.get(`${this.baseUrl}/status/sessions/history/all`, {
-        params: {
-          'X-Plex-Token': this.token,
-          'type': 4, // Type 4 is TV episode
-          'sort': 'viewedAt:desc',
-          'limit': limit
-        }
+        params: params
       });
 
       // Log response type and structure for debugging

--- a/src/services/RadarrService.js
+++ b/src/services/RadarrService.js
@@ -16,6 +16,10 @@ class RadarrService {
     // Normalize the URL by removing trailing slashes
     this.baseUrl = baseUrl ? baseUrl.replace(/\/+$/, '') : '';
     this.apiKey = apiKey;
+    
+    // Save to localStorage for persistence
+    if (baseUrl) localStorage.setItem('radarrBaseUrl', this.baseUrl);
+    if (apiKey) localStorage.setItem('radarrApiKey', this.apiKey);
   }
 
   /**


### PR DESCRIPTION
Adding Plex watch history integrations with 3 options.

- All previously available watch history is passed into the LLM
- The last 30 days watch history is passed into the LLM
- A checkbox indication you want to base recommendations ONLY off of your Plex watch history.
  - In this case your Sonarr/Radarr titles will be passed in as explicit items to not recommend since you already have them in your library.
  
  
<img width="1440" alt="Screenshot 2025-03-01 at 6 21 40 PM" src="https://github.com/user-attachments/assets/c0502f39-c4ba-4a9a-8749-39311c7a657b" />
